### PR TITLE
Enhancement: Restructuring Loner Names

### DIFF
--- a/init.py
+++ b/init.py
@@ -39,8 +39,8 @@ if os.path.exists("auto-updated"):
 setup_data_dir()
 timestr = time.strftime("%Y%m%d_%H%M%S")
 
-stdout_file = open(get_log_dir() + f"/stdout_{timestr}.log", "a")
-stderr_file = open(get_log_dir() + f"/stderr_{timestr}.log", "a")
+stdout_file = open(get_log_dir() + f"/stdout_{timestr}.log", "a", encoding="utf-8")
+stderr_file = open(get_log_dir() + f"/stderr_{timestr}.log", "a", encoding="utf-8")
 sys.stdout = UnbufferedStreamDuplexer(sys.stdout, stdout_file)
 sys.stderr = UnbufferedStreamDuplexer(sys.stderr, stderr_file)
 

--- a/resources/dicts/conditions/illnesses.json
+++ b/resources/dicts/conditions/illnesses.json
@@ -149,6 +149,10 @@
             {
                 "name": "yellowcough",
                 "chance": 60
+            },
+            {
+                "name": "sore throat",
+                "chance": 20
             }
         ],
         "herbs": {
@@ -194,6 +198,10 @@
             {
                 "name": "whitecough",
                 "chance": 10
+            },
+            {
+                "name": "sore throat",
+                "chance": 20
             }
         ],
         "herbs": {
@@ -360,6 +368,10 @@
             {
                 "name": "whitecough",
                 "chance": 15
+            },
+            {
+                "name": "sore throat",
+                "chance": 20
             }
         ],
         "herbs": {
@@ -400,6 +412,10 @@
             {
                 "name": "greencough",
                 "chance": 18
+            },
+            {
+                "name": "sore throat",
+                "chance": 20
             }
         ],
         "herbs": {
@@ -446,6 +462,10 @@
             {
                 "name": "redcough",
                 "chance": 80
+            },
+            {
+                "name": "sore throat",
+                "chance": 20
             }
         ],
         "herbs": {
@@ -689,6 +709,10 @@
             {
                 "name": "constant nightmares",
                 "chance": 15
+            },
+            {
+                "name": "selective mutism",
+                "chance": 150
             }
         ],
         "herbs": {

--- a/resources/dicts/conditions/injuries.json
+++ b/resources/dicts/conditions/injuries.json
@@ -24,7 +24,8 @@
             "torn ear",
             "blood loss"
         ],
-        "cause_permanent": [],
+        "cause_permanent": [
+        ],
         "herbs": {
             "1": [
             "cobwebs",
@@ -69,7 +70,8 @@
             "torn pelt",
             "blood loss"
         ],
-        "cause_permanent": [],
+        "cause_permanent": [
+        ],
         "herbs": {
             "1": [
             "cobwebs",
@@ -380,7 +382,8 @@
             "bruises"
         ],
         "cause_permanent": [
-            "crooked jaw"
+            "crooked jaw",
+            "damaged throat"
         ],
         "herbs": {
             "1": [
@@ -1213,7 +1216,8 @@
         "also_got": [],
         "cause_permanent": [
             "recurring shock",
-            "absent"
+            "absent",
+            "selective mutism"
         ],
         "herbs": {
             "1": [
@@ -1294,6 +1298,10 @@
         "risks": [
             {
                 "name": "heat exhaustion",
+                "chance": 10
+            },
+            {
+                "name": "sore throat",
                 "chance": 10
             }
         ],
@@ -1625,7 +1633,6 @@
         "also_got": [
         ],
         "cause_permanent": [
-            "absent"
         ],
         "herbs": {
             "1": [
@@ -1637,6 +1644,38 @@
             "3": [
                 "poppy"
             ]
+        }
+    },
+
+    "sore throat": {
+        "duration": 1,
+        "severity": "minor",
+        "medicine_duration": 1,
+        "mortality": {
+            "newborn": 0,
+            "kitten": 0,
+            "adolescent": 0,
+            "young adult": 0,
+            "adult": 0,
+            "senior adult": 0,
+            "senior": 0
+        },
+        "illness_infectiousness": [
+        ],
+        "risks": [
+        ],
+        "also_got": [
+        ],
+        "cause_permanent": [
+            "damaged throat"
+        ],
+             "herbs": {
+            "1": [
+            "poppy",
+            "juniper"
+        ],
+            "2": [],
+            "3": []
         }
     },
     

--- a/resources/dicts/conditions/permanent_conditions.json
+++ b/resources/dicts/conditions/permanent_conditions.json
@@ -490,6 +490,10 @@
             {
                 "name": "torn pelt",
                 "chance": 40
+            },
+            {
+                "name": "selective mutism",
+                "chance": 250
             }
         ],
         "herbs": {
@@ -754,6 +758,10 @@
             {
                 "name": "constant nightmares",
                 "chance": 20
+            },
+            {
+                "name": "selective mutism",
+                "chance": 250
             }
         ],
         "herbs": {
@@ -841,6 +849,62 @@
             "3": [
             "poppy"
             ]
+        }
+    },
+    "selective mutism": {
+        "severity": "minor",
+        "congenital": "sometimes",
+        "moons_until": 4,
+        "mortality": {
+            "newborn": 0,
+            "kitten": 0,
+            "adolescent": 0,
+            "young adult": 0,
+            "adult": 0,
+            "senior adult": 0,
+            "senior": 0
+        },
+        "illness_infectiousness": [
+        ],
+        "risks": [
+        ],
+        "herbs": {
+            "1": [
+            "poppy",
+            "juniper"
+        ],
+            "2": [],
+            "3": []
+        }
+    },
+    "damaged throat": {
+        "severity": "minor",
+        "congenital": "never",
+        "moons_until": 4,
+        "mortality": {
+            "newborn": 0,
+            "kitten": 0,
+            "adolescent": 0,
+            "young adult": 0,
+            "adult": 0,
+            "senior adult": 0,
+            "senior": 0
+        },
+        "illness_infectiousness": [
+        ],
+        "risks": [
+            {
+                "name": "sore throat",
+                "chance": 30
+            }
+        ],
+        "herbs": {
+            "1": [
+            "poppy",
+            "juniper"
+        ],
+            "2": [],
+            "3": []
         }
     }
 }

--- a/resources/lang/en/conditions/condition_got_strings/gain_congenital_condition_strings.json
+++ b/resources/lang/en/conditions/condition_got_strings/gain_congenital_condition_strings.json
@@ -68,6 +68,10 @@
         "m_c's jaw never seemed to close quite right, and {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} definitely not growing out of it.",
         "m_c has always had trouble suckling, but the reason why is only now starting to be really apparent."
     ],
+    "selective mutism": [
+        "When m_c is anxious, {PRONOUN/m_c/poss} voice freezes up, no matter how strongly {PRONOUN/m_c/subject} {VERB/m_c/want/wants} to speak up.",
+        "m_c keeps complaining about {PRONOUN/m_c/poss} words getting 'stuck' in {PRONOUN/m_c/poss} throat. r_c purrs that there are other ways for cats to communicate, even when {PRONOUN/m_c/poss} words fail {PRONOUN/m_c/object}."
+    ],
     "strange lump": [
             "m_c developed a new lump on {PRONOUN/m_c/poss} body. It doesn't look good.",
             "r_c isn't sure where this lump on {PRONOUN/m_c/poss} body came from, but m_c isn't sure it's good news.",

--- a/resources/lang/en/conditions/condition_got_strings/gain_permanent_condition_strings.json
+++ b/resources/lang/en/conditions/condition_got_strings/gain_permanent_condition_strings.json
@@ -6,6 +6,12 @@
             "m_c has been feeling the pain in {PRONOUN/m_c/poss} broken jaw lessen, but {PRONOUN/m_c/poss} teeth just don't fit together neatly like they used to.",
             "m_c can finally chew without pain, but it seems {PRONOUN/m_c/poss} jaw is permanently crooked now.",
             "While m_c is glad that {PRONOUN/m_c/poss} jaw is finally healed, it's still frustrating that it's now permanently twisted."
+        ],
+        "damaged throat": [
+            "m_c's jaw has healed, but {PRONOUN/m_c/poss} throat remains sore, making speech difficult.",
+            "m_c's jaw has been realigned, but the rest of {PRONOUN/m_c/poss} throat is another story.",
+            "r_c had assumed m_c's difficulty speaking was just the result of {PRONOUN/m_c/poss} broken jaw, but it appears the injury extended deeper into m_c's throat.",
+            "m_c tries to be optimistic: difficulty with speaking is certainly better than a broken jaw."
         ]
     },
     "broken bone": {
@@ -119,6 +125,10 @@
         "absent": [
             "m_c never really came around again after going into shock.",
             "m_c fails to respond to r_c yet again, leading {PRONOUN/r_c/subject} to accept m_c is never really coming back."
+        ],
+        "selective mutism": [
+            "m_c's nerves seem to have eased, until {PRONOUN/m_c/poss} voice gets caught in {PRONOUN/m_c/poss} chest.",
+            "Ever since going into shock, m_c struggles with communicating with other cats when {PRONOUN/m_c/subject} {VERB/m_c/become/becomes} stressed."
         ]
     },
     "head damage": {
@@ -218,6 +228,12 @@
             "A lump has appeared under m_c's wound. {PRONOUN/m_c/subject/CAP} {VERB/m_c/aren't/isn't} sure that's a good sign.",
             "m_c complains about being unable to sleep properly, leading r_c to find a strange lump under the wound.",
             "m_c won't let r_c see the new lump that appeared on {PRONOUN/m_c/poss} body."
+        ]
+    },
+    "sore throat": {
+        "damaged throat": [
+            "The soreness of m_c's throat has lessened, but {PRONOUN/m_c/subject} still {VERB/m_c/struggle/struggles} to mew and purr as {PRONOUN/m_c/subject} did before.",
+            "m_c's sore throat was a sign of greater damage to the area, making vocalization difficult."
         ]
     }
 }

--- a/resources/lang/en/conditions/healed_and_death_strings/injury_healed_strings.json
+++ b/resources/lang/en/conditions/healed_and_death_strings/injury_healed_strings.json
@@ -217,5 +217,10 @@
     "severe headache": [
         "m_c's headache is gone.",
         "m_c breathes a small sigh of relief. Finally, the deep throbbing in {PRONOUN/m_c/poss} head has subsided."
+    ],
+    "sore throat": [
+        "m_c's throat is no longer sore.",
+        "m_c's throat has healed."
     ]
+    
 }

--- a/resources/lang/en/conditions/injuries.en.json
+++ b/resources/lang/en/conditions/injuries.en.json
@@ -40,6 +40,7 @@
         "bee sting": "bee sting",
         "headache": "headache",
         "severe headache": "severe headache",
+        "sore throat": "sore throat",
         "pregnant": "pregnant"
     }
 }

--- a/resources/lang/en/conditions/permanent_conditions.en.json
+++ b/resources/lang/en/conditions/permanent_conditions.en.json
@@ -26,6 +26,8 @@
         "strange lump": "strange lump",
         "absent": "absent",
         "persistent headaches": "persistent headaches",
+        "selective mutism": "selective mutism",
+        "damaged throat": "damaged throat",
         "unknown_condition_risk_given": "m_c's condition has gotten worse."
     }
 }

--- a/resources/lang/en/conditions/risk_strings/illness_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/illness_risk_strings.json
@@ -4,6 +4,10 @@
              "There has to be a solution - if r_c tries hard enough, surely {PRONOUN/r_c/subject} can still save m_c from the yellowcough {PRONOUN/m_c/poss} greencough has progressed to.",
             "m_c sits miserably in the medicine cat den, coughing so hard it feels like {PRONOUN/m_c/subject} can barely get a breath in. The outlook looks grim as {PRONOUN/m_c/poss} greencough has progressed to yellowcough."
 
+        ],
+        "sore throat": [
+            "m_c's endless coughing has dried out {PRONOUN/m_c/poss} throat.",
+            "m_c's throat is sore from coughing."
         ]
     },
     "kittencough": {
@@ -11,6 +15,10 @@
             "r_c quietly tells m_c's parent that {PRONOUN/r_c/subject} {VERB/r_c/need/needs} to move m_c to the medicine cat den. m_c's kittencough has progressed to whitecough.",
             "m_c coughs pathetically, wondering why it's not getting better - and why {PRONOUN/m_c/subject} {VERB/m_c/have/has} to be in the stinky medicine cat den now."
 
+        ],
+        "sore throat": [
+            "m_c's endless coughing has dried out {PRONOUN/m_c/poss} throat.",
+            "m_c's throat is sore from coughing."
         ]
     },
     "an infected wound": {
@@ -25,6 +33,10 @@
             "r_c moves m_c to the medicine cat den, where the whitecough that {PRONOUN/m_c/poss} running nose has turned into can be more easily monitored.",
             "m_c brings {PRONOUN/m_c/self} to the medicine cat den, concerned {PRONOUN/m_c/poss} running nose only seems to be getting worse."
 
+        ],
+        "sore throat": [
+            "m_c's congestion has left {PRONOUN/m_c/poss} throat inflammed and sore.",
+            "As if a running nose wasn't enough trouble, now m_c's throat is sore as well."
         ]
     },
     "whitecough": {
@@ -39,6 +51,10 @@
             "r_c spots the specks of blood in the bedding where m_c has been coughing and swallows a wail of despair. If {PRONOUN/m_c/poss} yellowcough has progressed to redcough, it's practically a death sentence.",
              "m_c is going to be fine. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} sure of it. {PRONOUN/m_c/poss/CAP} lungs don't hurt nearly as much anymore, and if there's blood in {PRONOUN/m_c/poss} mouth when {PRONOUN/m_c/subject} {VERB/m_c/finish/finishes} a coughing fit, what of it?"
 
+        ],
+        "sore throat": [
+            "m_c's endless coughing has dried out {PRONOUN/m_c/poss} throat.",
+            "m_c's throat is sore from coughing."
         ]
     },
     "heat exhaustion": {
@@ -83,6 +99,10 @@
             "m_c wakes from yet another nightmare, feeling as though {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} being haunted by the ghost of the one {PRONOUN/m_c/subject} {VERB/m_c/grieve/grieves}.",
             "m_c wakes and wails, {PRONOUN/m_c/poss} dreams haunted by visions of {PRONOUN/m_c/poss} dead loved one.",
             "m_c jolts awake and immediately leaves the den to clear {PRONOUN/m_c/poss} head, hoping some fresh night air will help {PRONOUN/m_c/object} cope with the sadness and memories."
+        ],
+        "selective mutism": [
+            "m_c's voice suddenly gives out mid-conversation, the words clogging {PRONOUN/m_c/poss} throat.",
+            "m_c's grief has lessened with time, but the anxiety of losing a loved one remains, manifesting as selective mutism."
         ]
     }
 }

--- a/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
+++ b/resources/lang/en/conditions/risk_strings/injuries_risk_strings.json
@@ -157,6 +157,10 @@
         "heat exhaustion": [
             "r_c has managed to get some water into m_c, but {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} showing signs of confusion and fatigue - clear indications of heat exhaustion.",
             "m_c pants, helplessly searching for a cooler place to lie and nap. {PRONOUN/m_c/subject/CAP} {VERB/m_c/feel/feels} utterly exhausted by this heat."
+        ],
+        "sore throat": [
+            "The lack of water has left m_c's throat dry and sore.",
+            "r_c has tried to get some water into m_c, but {PRONOUN/m_c/poss} thirst has left {PRONOUN/m_c/poss} throat dry and scratchy."
         ]
     },
     "damaged eyes": {

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -3247,7 +3247,7 @@ class Cat:
         if make_clan:
             return "\n".join(
                 [
-                    self.genderalign,
+                    self.get_genderalign_string(),
                     i18n.t(
                         (
                             f"general.{self.age}"

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -260,6 +260,18 @@ class Name:
             else:
                 self.suffix = random.choice(self.names_dict["normal_suffixes"])
 
+    def get_specsuffix_name(self, rank: CatRank = CatRank.LEADER):
+        """
+        Return the cat's name with the appropriate special suffix. If no specsuffix is given for that rank, returns
+        default prefix + suffix. If specsuffix_hidden is true, return default prefix + suffix.
+        :param rank: CatRank matching
+        :return: Cat's name string
+        """
+        if rank in self.names_dict["special_suffixes"] and not self.specsuffix_hidden:
+            return self.prefix + self.names_dict["special_suffixes"][rank]
+
+        return self.prefix + self.suffix
+
     def __repr__(self):
         # Handles predefined suffixes (such as newborns being kit),
         # then suffixes based on ages (fixes #2004, just trust me)

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -462,6 +462,7 @@ class Condition_Events:
             "LEGBITE": ["weak leg"],
             "TOETRAP": ["weak leg"],
             "HINDLEG": ["weak leg"],
+            "THROAT": ["damaged throat"],
         }
 
         scarless_conditions = (
@@ -479,6 +480,7 @@ class Condition_Events:
             "recurring shock",
             "lasting grief",
             "persistent headaches",
+            "selective mutism",
         )
 
         got_condition = False

--- a/scripts/screens/MakeClanScreen.py
+++ b/scripts/screens/MakeClanScreen.py
@@ -259,14 +259,7 @@ class MakeClanScreen(Screens):
         elif event.ui_element == self.elements["reset_name"]:
             self.elements["name_entry"].set_text("")
         elif event.ui_element == self.elements["next_step"]:
-            new_name = sub(
-                r"[^A-Za-z0-9 ]+", "", self.elements["name_entry"].get_text()
-            ).strip()
-            if not new_name:
-                self.elements["error"].set_text("Your Clan's name cannot be empty")
-                self.elements["error"].show()
-                return
-            self.clan_name = new_name
+            self.clan_name = self.elements["name_entry"].get_text()
             self.open_choose_leader()
         elif event.ui_element == self.elements["previous_step"]:
             self.clan_name = ""
@@ -1075,7 +1068,9 @@ class MakeClanScreen(Screens):
 
         if self.sub_screen == "choose leader":
             self.elements["cat_name"].set_text(
-                str(selected.name) + " --> " + selected.name.prefix + "star"
+                str(selected.name)
+                + " --> "
+                + selected.name.get_specsuffix_name(CatRank.LEADER)
             )
         else:
             self.elements["cat_name"].set_text(str(selected.name))
@@ -1432,9 +1427,7 @@ class MakeClanScreen(Screens):
             ui_scale(pygame.Rect((265, 597), (140, 29))),
             manager=MANAGER,
         )
-        self.elements["name_entry"].set_allowed_characters(
-            list("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_- ")
-        )
+        self.elements["name_entry"].set_forbidden_characters("forbidden_file_path")
         self.elements["name_entry"].set_text_length_limit(11)
         self.elements["clan"] = pygame_gui.elements.UITextBox(
             "-Clan",
@@ -2134,12 +2127,13 @@ class MakeClanScreen(Screens):
         save_load.faded_ids.clear()
         Cat.outside_cats.clear()
         Patrol.used_patrols.clear()
-        convert_camp = {1: "camp1", 2: "camp2", 3: "camp3", 4: "camp4"}
+        convert_camp = f"camp{self.selected_camp_tab}"
         displayname = self.clan_name
-        if self._clan_name_exists(self.clan_name):
-            clan_name = self._generate_unique_clan_name(self.clan_name)
-        else:
-            clan_name = self.clan_name
+
+        # extra sanitization for filenames
+        clan_name = sub(r"[/\\?%*:|\"<>\x7F\x00-\x1F]", "-", self.clan_name)
+        if self._clan_name_exists(clan_name):
+            clan_name = self._generate_unique_clan_name(clan_name)
 
         game.clan = Clan(
             name=clan_name,
@@ -2148,7 +2142,7 @@ class MakeClanScreen(Screens):
             deputy=self.deputy,
             medicine_cat=self.med_cat,
             biome=self.biome_selected,
-            camp_bg=convert_camp[self.selected_camp_tab],
+            camp_bg=convert_camp,
             symbol=self.symbol_selected,
             game_mode=self.game_mode,
             starting_members=self.members,


### PR DESCRIPTION
## About The Pull Request

Splits loner names into three categories.
*Loner* names include common words ("Abyss"), terms of endearment ("Baby"), and food items ("Smores").
*Popculture* names include silly names ("Wigglebutt"), fandom references ("Hatsune Miku"), and complicated terms cats would not reasonably hear ("Exothermic Reaction"). Most longer/multi-word names were also placed here.
*Human* names are names which you would see in real life ("Todd").

Fixed three loner names with typos. (Pumba -> Pumbaa, Pushee -> Pusheen, Quickie -> Quicky)

Added the following new names:
Bubba (loner) - a common term of endearment! we called my late cat this
Hatshepsut (pop culture) - the most famous female pharaoh in egypt
Mobius (pop culture) - reference to mobius strip
Bingus (pop culture) - famous bald cat
Nuka Cola (pop culture) - soda brand in the Fallout universe
Belphegor (pop culture) - famous cat on tumblr (we have pangur already, who has the same owner)
Grim (pop culture) - famous cat on tumblr (of pangur-and-grim fame), also the name of the cat in Twisted Wonderland
Rambley (pop culture) - reference to indigo park
Ghoul (loner) - more spooky names
Tribbie (pop culture) - character from honkai star rail
Ursula (human) - noticed we had Ursala but not Ursula, which is more common
Valentine (pop culture) - holiday
Ulysses (pop culture) - greek mythology
Riddle (loner) - technically intended as a twisted wonderland reference but it's also just a fun word for a name

In cases where a name could go into multiple categories, I used my best judgment and generally followed the following guidelines:
- if something could be a reference or just a normal name, it was placed in human names (ex. "Ringo")
- if something could be a regular word or a human name, it was placed in loner names (ex. "Glory")
- if something could be a popculture reference or a common word, it was placed in loner names (ex. "Sonic")

## Why This Is Good For ClanGen
This allows us to add more fun names without skewing the ratio of "normal" cat names to weird and fun ones. It is also fully adjustable in the game config for those who want more serious playthroughs!


## Proof of Testing

<img width="719" height="549" alt="image" src="https://github.com/user-attachments/assets/879cb633-dd79-410a-8aec-99209a540cf1" />
<img width="727" height="565" alt="image" src="https://github.com/user-attachments/assets/1647c2c1-c7c9-438a-a911-84faf7e9aee5" />
<img width="723" height="574" alt="image" src="https://github.com/user-attachments/assets/117e37e2-e740-4c73-896c-e158d1541159" />


## Changelog/Credits
credit to dinofelisDruid